### PR TITLE
spruce up lazy-map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.idea/
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 language: clojure
+matrix:
+  include:
+    - jdk: openjdk12
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+after_success:
+  - lein cloverage --codecov
+  - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: clojure
-matrix:
-  include:
-    - jdk: openjdk12
-      before_install:
-        - rm "${JAVA_HOME}/lib/security/cacerts"
-        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
 after_success:
   - lein cloverage --codecov
   - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json

--- a/README.md
+++ b/README.md
@@ -121,11 +121,8 @@ placeholder. Here is an illustration:
 
 Finally, lazy maps will automatically avoid computing their values
 when they are converted to strings using `str`, `pr-str`, and
-`print-dup`.
-
-Check out the [unit tests] for more information on the exact behavior of lazy maps.
-
-[unit tests](./test/lazy_map/core_test.clj)
+`print-dup`. Please see the [unit tests](./test/lazy_map/core_test.clj) 
+for more examples of the exact behavior of lazy maps.
 
 ## Organization
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# lazy-map
+[![Build Status](https://travis-ci.org/Guaranteed-Rate/lazy-map.svg?branch=master)](https://travis-ci.org/Guaranteed-Rate/lazy-map)
+[![Clojars Project](https://img.shields.io/clojars/v/com.guaranteedrate/lazy-map.svg)](https://clojars.org/com.guaranteedrate/lazy-map)
+[![codecov](https://codecov.io/gh/Guaranteed-Rate/lazy-map/branch/master/graph/badge.svg)](https://codecov.io/gh/Guaranteed-Rate/lazy-map)
 
-> Lazy maps for Clojure
-
-[![Travis build status][travis icon]][travis]
-
-[travis]: https://travis-ci.org/thinktopic/lazy-map
-[travis icon]: https://travis-ci.org/thinktopic/lazy-map.svg?branch=master
+> Maps that satisfy Clojure's map interactions but delay computing their values until the values are accessed.
 
 ## Summary
 
@@ -91,17 +88,12 @@ values with a placeholder. Here is an illustration:
 
 Finally, lazy maps will automatically avoid computing their values
 when they are converted to strings using `str`, `pr-str`, and
-`print-dup`. To accomplish the same for `pprint`, you must use a
-special pretty-print dispatch function:
-
-    user> (pp/with-pprint-dispatch lm/lazy-map-dispatch
-            (pp/pprint (lm/lazy-map {:a (println "lazy")})))
-    {:a <unrealized>}
+`print-dup`.
 
 Check out the [unit tests] for more information on the exact behavior
 of lazy maps.
 
-[unit tests]: src/lazy_map/core_test.clj
+[unit tests](./test/lazy_map/core_test.clj)
 
 ## Organization
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Clojars Project](https://img.shields.io/clojars/v/com.guaranteedrate/lazy-map.svg)](https://clojars.org/com.guaranteedrate/lazy-map)
 [![codecov](https://codecov.io/gh/Guaranteed-Rate/lazy-map/branch/master/graph/badge.svg)](https://codecov.io/gh/Guaranteed-Rate/lazy-map)
 
-> Maps that satisfy Clojure's map interactions but delay computing their values until the values are accessed.
+> Maps that satisfy Clojure's map interactions but delay computing their values until the value is accessed.
 
 ## Summary
 
@@ -14,55 +14,85 @@ are not computed until they are requested.
 
 Start by requiring the namespace:
 
-    user> (require '[lazy-map.core :as lm])
+```clojure 
+
+(require '[lazy-map.core :as lm])
+
+```
 
 You can then construct a lazy map using the `lazy-map` macro.
 
-    user> (def m (lm/lazy-map {:a (do (println "resolved :a") "value :a")
-                               :b (do (println "resolved :b") "value :b")}))
-    #'user/m
-    user> m
-    {:a <unrealized>, :b <unrealized>}
+```clojure 
+
+(def m (lm/lazy-map 
+        {:a (do (println "resolved :a") "value :a")
+         :b (do (println "resolved :b") "value :b")}))
+
+; => {:a <unrealized>, :b <unrealized>}
+
+```
 
 When you request a value from the map, it will be evaluated and its
 value will be cached:
 
-    user> (:a m)
-    resolved :a
-    "value :a"
-    user> (:a m)
-    "value :a"
+```clojure
+
+(:a m)
+
+; => resolved :a
+; => "value :a"
+
+(:a m)
+; => "value :a"
+
+```
 
 You can `assoc` values onto lazy maps just like regular maps. If you
 `assoc` a delay, it will be treated as an unrealized value and not
 forced until necessary:
 
-    user> (assoc (lm/lazy-map {}) :a 1 :b (delay 2))
-    {:a 1, :b <unrealized>}
+```clojure
+
+(assoc (lm/lazy-map {}) :a 1 :b (delay 2))
+
+; => {:a 1, :b <unrealized>}
+
+```
 
 Lazy maps are very lazy. In practice, this means they probably will
 not compute their values until absolutely necessary. For example,
 taking the `seq` of a lazy map does not force any computation, and map
 entries have been made lazy as well:
 
-    user> (def m (lm/lazy-map {:a (do (println "resolved :a") "value :a")
-                               :b (do (println "resolved :b") "value :b")}))
-    #'lazy-map.core/m
-    lazy-map.core> (dorun m)
-    nil
-    lazy-map.core> (keys m)
-    (:a :b)
-    lazy-map.core> (key (first m))
-    :a
-    lazy-map.core> (val (first m))
-    resolved :a
-    "value :a"
+```clojure
+
+(def m (lm/lazy-map 
+        {:a (do (println "resolved :a") "value :a")
+         :b (do (println "resolved :b") "value :b")}))
+
+; => #'lazy-map.core/m
+(dorun m)
+; => nil
+(keys m)
+; => (:a :b)
+(key (first m))
+; => :a
+(val (first m))
+; => resolved :a
+; => "value :a"
+
+```
 
 You can also initialize a lazy map from a regular map, where delays
 are taken as unrealized values:
 
-    user> (lm/->LazyMap {:a 1 :b (delay 2)})
-    {:a 1, :b <unrealized>}
+```clojure 
+
+(lm/->LazyMap {:a 1 :b (delay 2)})
+
+; => {:a 1, :b <unrealized>}
+
+```
 
 You might prefer to use `->?LazyMap` instead of `->LazyMap`. The only
 difference is that `->?LazyMap` acts as the identity function if you
@@ -71,27 +101,29 @@ which are not inherently wrong but which could be bad for performance
 if you nest them thousands of layers deep.
 
 There are also some utility functions for dealing with lazy maps. You
-can use `force-map` to compute all of the values in a lazy map.
-Alternatively, you can use `freeze-map` to replace all the unrealized
-values with a placeholder. Here is an illustration:
+can use `force-map` to compute all values in a lazy map. Alternatively, 
+you can use `freeze-map` to replace all the unrealized values with a 
+placeholder. Here is an illustration:
 
-    user> (lm/force-map
-            (lm/->LazyMap {:a (delay :foo)
-                           :b :bar}))
-    {:a :foo, :b :bar}
-    user> (lm/force-map
-            (lm/freeze-map
-              :quux
-              (lm/->LazyMap {:a (delay :foo)
-                             :b :bar})))
-    {:a :quux, :b :bar}
+```clojure 
+
+(lm/force-map (lm/->LazyMap {:a (delay :foo) :b :bar}))
+
+; => {:a :foo, :b :bar}
+
+(lm/force-map
+  (lm/freeze-map :quux
+     (lm/->LazyMap {:a (delay :foo) :b :bar})))
+
+; => {:a :quux, :b :bar}
+
+```
 
 Finally, lazy maps will automatically avoid computing their values
 when they are converted to strings using `str`, `pr-str`, and
 `print-dup`.
 
-Check out the [unit tests] for more information on the exact behavior
-of lazy maps.
+Check out the [unit tests] for more information on the exact behavior of lazy maps.
 
 [unit tests](./test/lazy_map/core_test.clj)
 

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,6 @@
-(defproject thinktopic/lazy-map "0.1.1-SNAPSHOT"
+(defproject com.guaranteedrate/lazy-map "0.1.1-SNAPSHOT"
   :description "Lazy maps for Clojure"
-  :url "https://github.com/thinktopic/lazy-map"
+  :url "https://github.com/Guaranteed-Rate/lazy-map"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :think/meta {:type :library
-               :tags [:clojure :utility :data-type]}
-  :dependencies [[org.clojure/clojure "1.8.0"]]
-  :profiles {:repl {:main lazy-map.core}})
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.10.1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,17 @@
 (defproject com.guaranteedrate/lazy-map "0.1.1-SNAPSHOT"
-  :description "Lazy maps for Clojure"
-  :url "https://github.com/Guaranteed-Rate/lazy-map"
-  :license {:name "Eclipse Public License"
-            :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]])
+
+  :description
+  "Lazy maps for Clojure"
+
+  :url
+  "https://github.com/Guaranteed-Rate/lazy-map"
+
+  :license
+  {:name "Eclipse Public License"
+   :url  "http://www.eclipse.org/legal/epl-v10.html"}
+
+  :dependencies
+  [[org.clojure/clojure "1.10.1"]]
+
+  :plugins
+  [[lein-cloverage "1.1.2"]])

--- a/src/lazy_map/core.clj
+++ b/src/lazy_map/core.clj
@@ -4,19 +4,20 @@
 
   Public API is `->LazyMap`, `->?LazyMap`, `lazy-map`, `force-map`,
   `freeze-map`, `lazy-map-dispatch`."
-  (:require [clojure
-             [pprint :as pp]
-             [string :as str]])
-  (:import java.io.Writer))
+  (:require [clojure.pprint :as pp]
+            [clojure.walk :as walk]
+            [clojure.set :as sets])
+  (:import java.io.Writer
+           (java.util Map RandomAccess Map$Entry)
+           (clojure.lang Seqable IPersistentMap
+                         IPersistentCollection IMapIterable
+                         ILookup IKVReduce IFn Associative
+                         Sequential Reversible IPersistentVector
+                         IPersistentStack Indexed IMapEntry IHashEq MapEntry)
+           (java.io Serializable))
+  (:refer-clojure :exclude (merge)))
 
 ;;;; Utility functions
-
-(defmacro is-not-thrown?
-  "Used in clojure.test assertions because (is (not (thrown? ...)))
-  doesn't work. See http://acidwords.com/posts/2015-07-23-fixing-negation-in-clojure-test.html"
-  [e expr]
-  {:style/indent 1}
-  `(is (not ('thrown? ~e ~expr))))
 
 (defmacro extend-print
   "Convenience macro for overriding the string representation of a
@@ -40,23 +41,7 @@
   "Creates a map entry (as returned by calling seq on a map) with the
   given key and value."
   [k v]
-  (clojure.lang.MapEntry/create k v))
-
-(defn map-keys
-  "Applies f to each of the keys of a map, returning a new map."
-  [f map]
-  (reduce-kv (fn [m k v]
-               (assoc m (f k) v))
-             {}
-             map))
-
-(defn map-vals
-  "Applies f to each of the values of a map, returning a new map."
-  [f map]
-  (reduce-kv (fn [m k v]
-               (assoc m k (f v)))
-             {}
-             map))
+  (MapEntry/create k v))
 
 ;;;; PlaceholderText type
 
@@ -68,7 +53,7 @@
 
 (deftype LazyMapEntry [key_ val_]
 
-  clojure.lang.Associative
+  Associative
   (containsKey [this k]
     (boolean (#{0 1} k)))
   (entryAt [this k]
@@ -83,17 +68,17 @@
       (= k 2) (vector k (force val_) v)
       :else (throw (IndexOutOfBoundsException.))))
 
-  clojure.lang.IFn
+  IFn
   (invoke [this k]
     (.valAt this k))
 
-  clojure.lang.IHashEq
+  IHashEq
   (hasheq [this]
     (.hasheq
-      ^clojure.lang.IHashEq
+      ^IHashEq
       (vector key_ (force val_))))
 
-  clojure.lang.ILookup
+  ILookup
   (valAt [this k]
     (cond
       (= k 0) key_
@@ -105,11 +90,11 @@
       (= k 1) (force val_)
       :else not-found))
 
-  clojure.lang.IMapEntry
+  IMapEntry
   (key [this] key_)
   (val [this] (force val_))
 
-  clojure.lang.Indexed
+  Indexed
   (nth [this i]
     (cond
       (= i 0) key_
@@ -122,7 +107,7 @@
       (.nth this i)
       (catch Exception _ not-found)))
 
-  clojure.lang.IPersistentCollection
+  IPersistentCollection
   (count [this] 2)
   (empty [this] false)
   (equiv [this o]
@@ -130,52 +115,52 @@
       [key_ (force val_)]
       o))
 
-  clojure.lang.IPersistentStack
+  IPersistentStack
   (peek [this] (force val_))
   (pop [this] [key_])
 
-  clojure.lang.IPersistentVector
+  IPersistentVector
   (assocN [this i v]
     (.assocN [key_ (force val_)] i v))
   (cons [this o]
     (.cons [key_ (force val_)] o))
 
-  clojure.lang.Reversible
+  Reversible
   (rseq [this] (lazy-seq (list (force val_) key_)))
 
-  clojure.lang.Seqable
+  Seqable
   (seq [this]
     (cons key_ (lazy-seq (list (force val_)))))
 
-  clojure.lang.Sequential
+  Sequential
 
-  java.io.Serializable
+  Serializable
 
-  java.lang.Comparable
+  Comparable
   (compareTo [this o]
     (.compareTo
-      ^java.lang.Comparable
+      ^Comparable
       (vector key_ (force val_))
       o))
 
-  java.lang.Iterable
+  Iterable
   (iterator [this]
     (.iterator
-      ^java.lang.Iterable
+      ^Iterable
       (.seq this)))
 
-  java.lang.Object
+  Object
   (toString [this]
     (str [key_ (if (and (delay? val_)
                         (not (realized? val_)))
                  (->PlaceholderText "<unrealized>")
                  (force val_))]))
 
-  java.util.Map$Entry
+  Map$Entry
   (getKey [this] key_)
   (getValue [this] (force val_))
 
-  java.util.RandomAccess)
+  RandomAccess)
 
 (defn lazy-map-entry
   "Construct a lazy map entry with the given key and value. If you
@@ -194,9 +179,9 @@
 ;; deftype.
 (declare freeze-map)
 
-(deftype LazyMap [^clojure.lang.IPersistentMap contents]
+(deftype LazyMap [^IPersistentMap contents]
 
-  clojure.lang.Associative
+  Associative
   (containsKey [this k]
     (and contents
          (.containsKey contents k)))
@@ -204,17 +189,17 @@
     (and contents
          (lazy-map-entry k (.valAt contents k))))
 
-  clojure.lang.IFn
+  IFn
   (invoke [this k]
     (.valAt this k))
   (invoke [this k not-found]
     (.valAt this k not-found))
 
-  clojure.lang.IKVReduce
+  IKVReduce
   (kvreduce [this f init]
     (reduce-kv f init (into {} this)))
 
-  clojure.lang.ILookup
+  ILookup
   (valAt [this k]
     (and contents
          (force (.valAt contents k))))
@@ -224,21 +209,21 @@
     (and contents
          (force (.valAt contents k not-found))))
 
-  clojure.lang.IMapIterable
+  IMapIterable
   (keyIterator [this]
     (.iterator
-      ^java.lang.Iterable
-      (keys contents)))
+      ^Iterable
+      (or (keys contents) ())))
   (valIterator [this]
     (.iterator
       ;; Using the higher-arity form of map prevents chunking.
-      ^java.lang.Iterable
+      ^Iterable
       (map (fn [[k v] _]
              (force v))
            contents
            (repeat nil))))
 
-  clojure.lang.IPersistentCollection
+  IPersistentCollection
   (count [this]
     (if contents
       (.count contents)
@@ -250,30 +235,29 @@
     (LazyMap. (.cons (or contents {}) o)))
   (equiv [this o]
     (.equiv
-      ^clojure.lang.IPersistentCollection
+      ^IPersistentCollection
       (into {} this) o))
 
-  clojure.lang.IPersistentMap
+  IPersistentMap
   (assoc [this key val]
     (LazyMap. (.assoc (or contents {}) key val)))
   (without [this key]
     (LazyMap. (.without (or contents {}) key)))
 
-  clojure.lang.Seqable
+  Seqable
   (seq [this]
     ;; Using the higher-arity form of map prevents chunking.
-    (map (fn [[k v] _]
-           (lazy-map-entry k v))
-         contents
-         (repeat nil)))
+    (seq
+      (map (fn [[k v] _]
+             (lazy-map-entry k v))
+           contents
+           (repeat nil))))
 
-  java.lang.Iterable
+  Iterable
   (iterator [this]
-    (.iterator
-      ^java.lang.Iterable
-      (.seq this)))
+    (.iterator ^Iterable (.seq this)))
 
-  java.lang.Object
+  Object
   (toString [this]
     (str (freeze-map (->PlaceholderText "<unrealized>") this))))
 
@@ -296,21 +280,39 @@
     map
     (->LazyMap map)))
 
+(defprotocol LazyRewrite
+  (rewrite [form]
+    "Rewrites form into a lazy construct."))
+
+(extend-protocol LazyRewrite
+  Object
+  (rewrite [form]
+    form)
+  IMapEntry
+  (rewrite [[k v]]
+    [(rewrite k) `(delay ~(rewrite v))])
+  Map
+  (rewrite [form]
+    `(->LazyMap (hash-map ~@(mapcat rewrite form)))))
+
+
 (defmacro lazy-map
   "Constructs a lazy map from a literal map. None of the values are
-  evaluated until they are accessed from the map."
-  [map]
-  `(->LazyMap
-     ~(->> map
-        (apply concat)
-        (partition 2)
-        (clojure.core/map (fn [[k v]] [k `(delay ~v)]))
-        (into {}))))
+  evaluated until they are accessed from the map. Recursively converts
+  any nested inline maps as well."
+  [form]
+  (rewrite form))
+
 
 (defn force-map
   "Realizes all the values in a lazy map, returning a regular map."
   [map]
-  (into {} map))
+  (walk/postwalk
+    (fn [form]
+      (if (map? form)
+        (into {} form)
+        form))
+    map))
 
 (defn freeze-map
   "Replace all the unrealized values in a lazy map with placeholders,
@@ -329,21 +331,59 @@
                {}
                (.contents ^LazyMap map))))
 
-(defn lazy-map-dispatch
-  "This is a dispatch function for clojure.pprint that prints
-  lazy maps without forcing them."
-  [obj]
-  (cond
-    (instance? LazyMap obj)
-    (pp/simple-dispatch (freeze-map (->PlaceholderText "<unrealized>") obj))
-    (instance? LazyMapEntry obj)
-    (pp/simple-dispatch
-      (let [raw-value (.val_ obj)]
-        (assoc obj 1 (if (and (delay? raw-value)
-                              (not (realized? raw-value)))
-                       (->PlaceholderText "<unrealized>")
-                       (force raw-value)))))
-    (instance? PlaceholderText obj)
-    (pr obj)
-    :else
-    (pp/simple-dispatch obj)))
+
+(defn merge
+  "Merges two lazy maps. Preserves laziness of value access."
+  [m1 m2]
+  (letfn [(value [k]
+            (case [(contains? m1 k) (contains? m2 k)]
+              [true true] (if-some [v (get m2 k)] v (get m1 k))
+              [true false] (get m1 k)
+              [false true] (get m2 k)
+              [false false] nil))]
+    (->> (sets/union (keys m1) (keys m2))
+         (into {} (map (fn [k] [k (delay (value k))])))
+         (->LazyMap))))
+
+
+(defn deep-merge
+  "Deep merges two lazy maps. Preserves laziness of value access."
+  [m1 m2]
+  (letfn [(value [k]
+            (case [(contains? m1 k) (contains? m2 k)]
+              [true true] (if-some [m2v (get m2 k)]
+                            (if (map? m2v)
+                              (let [m1v (get m1 k)]
+                                (if (map? m1v)
+                                  (deep-merge m1v m2v)
+                                  m2v))
+                              m2v)
+                            (get m1 k))
+              [true false] (get m1 k)
+              [false true] (get m2 k)
+              [false false] nil))]
+    (->> (sets/union (keys m1) (keys m2))
+         (into {} (map (fn [k] [k (delay (value k))])))
+         (->LazyMap))))
+
+
+(defonce _init
+  (when-not *compile-files*
+    (alter-var-root #'pp/*print-pprint-dispatch*
+      (fn [old]
+        (let [dispatch (or old pp/simple-dispatch)]
+          (fn [obj]
+            (cond
+              (instance? LazyMap obj)
+              (dispatch (freeze-map (->PlaceholderText "<unrealized>") obj))
+              (instance? LazyMapEntry obj)
+              (dispatch
+                (let [raw-value (.val_ obj)]
+                  (assoc obj 1 (if (and (delay? raw-value)
+                                        (not (realized? raw-value)))
+                                 (->PlaceholderText "<unrealized>")
+                                 (force raw-value)))))
+              (instance? PlaceholderText obj)
+              (pr obj)
+              :else
+              (dispatch obj))))))))

--- a/test/lazy_map/core_test.clj
+++ b/test/lazy_map/core_test.clj
@@ -2,7 +2,8 @@
   (:require [lazy-map.core :refer :all]
             [clojure.test :refer :all]
             [clojure.pprint :as pp])
-  (:import [lazy_map.core LazyMap]))
+  (:import [lazy_map.core LazyMap])
+  (:refer-clojure :exclude (merge)))
 
 (defmacro error
   [& [msg]]
@@ -10,20 +11,6 @@
      (throw (if msg#
               (AssertionError. msg#)
               (AssertionError.)))))
-
-(deftest map-keys-test
-  (is (= (map-keys name {:a 1 :b 2})
-         {"a" 1 "b" 2}))
-  (is (= (map-keys inc {1 2 3 4})
-         {2 2 4 4}))
-  (is (= (map-keys #(error "key fn should not be called") {})
-         {})))
-
-(deftest map-vals-test
-  (is (= (map-vals dec {:a 1 :b 2})
-         {:a 0 :b 1}))
-  (is (= (map-vals #(cons 0 %) {[1 2] [3 4] [5 6] [7 8]})
-         {[1 2] [0 3 4] [5 6] [0 7 8]})))
 
 (deftest map-entry-test
   (is (= (key (map-entry :a :b)) :a))
@@ -61,23 +48,23 @@
                   {:a (delay (println "value :a was realized"))
                    :b (delay (println "value :b was realized"))
                    :c (delay (println "value :c was realized"))})
-             (vals)
-             (take 2)
-             (dorun)
-             (with-out-str)
-             (re-seq #"value :[a-c] was realized")
-             (count))
+                (vals)
+                (take 2)
+                (dorun)
+                (with-out-str)
+                (re-seq #"value :[a-c] was realized")
+                (count))
            2)))
   (testing "assoc and dissoc work with lazy maps"
     (is (= (-> (make-lazy-map)
-             (assoc :d (delay (error "value :d should not be realized")))
-             (keys)
-             (set))
+               (assoc :d (delay (error "value :d should not be realized")))
+               (keys)
+               (set))
            #{:a :b :c :d}))
     (is (= (-> (make-lazy-map)
-             (dissoc :a :b)
-             (keys)
-             (set))
+               (dissoc :a :b)
+               (keys)
+               (set))
            #{:c})))
   (testing "lazy maps support default value for lookup"
     (is (= (:d (make-lazy-map) :default)
@@ -121,11 +108,9 @@
     (is (= (pr-str (->LazyMap {:a (delay 1)}))
            "{:a <unrealized>}")))
   (testing "pprint representation of lazy maps"
-    (is (= (with-out-str (pp/with-pprint-dispatch lazy-map-dispatch
-                           (pp/pprint (->LazyMap {:a 1}))))
+    (is (= (with-out-str (pp/pprint (->LazyMap {:a 1})))
            (format "{:a 1}%n")))
-    (is (= (with-out-str (pp/with-pprint-dispatch lazy-map-dispatch
-                           (pp/pprint (->LazyMap {:a (delay 1)}))))
+    (is (= (with-out-str (pp/pprint (->LazyMap {:a (delay 1)})))
            (format "{:a <unrealized>}%n"))))
   (testing "str representation of lazy map entries"
     (is (= (str (lazy-map-entry :a 1))
@@ -138,11 +123,9 @@
     (is (= (pr-str (lazy-map-entry :a (delay 1)))
            "[:a <unrealized>]")))
   (testing "pprint representation of lazy map entries"
-    (is (= (with-out-str (pp/with-pprint-dispatch lazy-map-dispatch
-                           (pp/pprint (lazy-map-entry :a 1))))
+    (is (= (with-out-str (pp/pprint (lazy-map-entry :a 1)))
            (format "[:a 1]%n")))
-    (is (= (with-out-str (pp/with-pprint-dispatch lazy-map-dispatch
-                           (pp/pprint (lazy-map-entry :a (delay 1)))))
+    (is (= (with-out-str (pp/pprint (lazy-map-entry :a (delay 1))))
            (format "[:a <unrealized>]%n"))))
   (testing "->?LazyMap function"
     (is (= (:b (make-lazy-map ->?LazyMap))
@@ -163,19 +146,31 @@
     (is (= (->> (lazy-map
                   {:a (println "value :a was realized")
                    :b (println "value :b was realized")})
-             (force-map)
-             (with-out-str)
-             (re-seq #"value :[ab] was realized")
-             (set))
+                (force-map)
+                (with-out-str)
+                (re-seq #"value :[ab] was realized")
+                (set))
            #{"value :a was realized" "value :b was realized"})))
   (testing "freezing a lazy map"
     (= (->> (make-lazy-map)
-         (freeze-map :foo))
+            (freeze-map :foo))
        {:a :foo
         :b 50
         :c :foo})
     (= (->> (make-lazy-map)
-         (freeze-map name))
+            (freeze-map name))
        {:a "a"
         :b 50
-        :c "c"})))
+        :c "c"}))
+  (testing "keyIterator and valIterator"
+    (is (= false (.hasNext (.keyIterator (lazy-map {})))))
+    (is (= true (.hasNext (.keyIterator (lazy-map {:a 1})))))
+    (is (= :a (.next (.keyIterator (lazy-map {:a 1})))))
+    (is (= :a (.next (.keyIterator (lazy-map {:a 1})))))
+    (is (= false (.hasNext (.valIterator (lazy-map {})))))
+    (is (= true (.hasNext (.valIterator (lazy-map {:a 1})))))
+    (is (= 1 (.next (.valIterator (lazy-map {:a 1}))))))
+  (testing "empty maps"
+    (is (empty? (keys (lazy-map {}))))
+    (is (empty? (vals (lazy-map {}))))
+    (is (= (count (lazy-map {})) 0))))


### PR DESCRIPTION
The canonical repo [originrose/lazy-map](https://github.com/originrose/lazy-map) is abandoned and the original maintainer no longer has contributor rights. I'm establishing a new fork to fix some known bugs and add support for merging lazy maps in order to support something I'm working on.


- fork artifact coordinates
- add code coverage tracking
- add badges to README.md
- fix known bugs in existing implementation
- make lazy-map recursively transform inline maps
- add merge and deep-merge that respect laziness
- remove need for manual pprint configuration