### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Start by requiring the namespace:
 
 ```
 
-You can then construct a lazy map using the `lazy-map` macro.
+You can then construct a lazy map using the `literal->lazy-map` macro.
 
 ```clojure 
 
-(def m (lm/lazy-map 
+(def m (lm/literal->lazy-map 
         {:a (do (println "resolved :a") "value :a")
          :b (do (println "resolved :b") "value :b")}))
 
@@ -53,7 +53,7 @@ forced until necessary:
 
 ```clojure
 
-(assoc (lm/lazy-map {}) :a 1 :b (delay 2))
+(assoc (lm/literal->lazy-map {}) :a 1 :b (delay 2))
 
 ; => {:a 1, :b <unrealized>}
 
@@ -66,7 +66,7 @@ entries have been made lazy as well:
 
 ```clojure
 
-(def m (lm/lazy-map 
+(def m (lm/literal->lazy-map 
         {:a (do (println "resolved :a") "value :a")
          :b (do (println "resolved :b") "value :b")}))
 
@@ -88,17 +88,11 @@ are taken as unrealized values:
 
 ```clojure 
 
-(lm/->LazyMap {:a 1 :b (delay 2)})
+(lm/lazy-map {:a 1 :b (delay 2)})
 
 ; => {:a 1, :b <unrealized>}
 
 ```
-
-You might prefer to use `->?LazyMap` instead of `->LazyMap`. The only
-difference is that `->?LazyMap` acts as the identity function if you
-pass it a map that is already lazy. This prevents nested lazy maps,
-which are not inherently wrong but which could be bad for performance
-if you nest them thousands of layers deep.
 
 There are also some utility functions for dealing with lazy maps. You
 can use `force-map` to compute all values in a lazy map. Alternatively, 
@@ -107,36 +101,33 @@ placeholder. Here is an illustration:
 
 ```clojure 
 
-(lm/force-map (lm/->LazyMap {:a (delay :foo) :b :bar}))
+(lm/force-map (lm/lazy-map {:a (delay :foo) :b :bar}))
 
 ; => {:a :foo, :b :bar}
 
 (lm/force-map
   (lm/freeze-map :quux
-     (lm/->LazyMap {:a (delay :foo) :b :bar})))
+     (lm/lazy-map {:a (delay :foo) :b :bar})))
 
 ; => {:a :quux, :b :bar}
 
 ```
 
-Finally, lazy maps will automatically avoid computing their values
+Finally, lazy maps will automatically avoid realizing their values
 when they are converted to strings using `str`, `pr-str`, and
 `print-dup`. Please see the [unit tests](./test/lazy_map/core_test.clj) 
 for more examples of the exact behavior of lazy maps.
 
-## See also
+## Comparisons
 
-**[Malabarba's implementation] of lazy maps in Clojure.**
-
-[Malabarba's implementation]: https://github.com/Malabarba/lazy-map-clojure
-
-Features unique to `malabarba/lazy-map`:
-
-* ClojureScript support
-* Transform Java classes into lazy maps (methods become keys)
-
-Features unique to `com.guaranteedrate/lazy-map`:
+Features unique to [com.guaranteedrate/lazy-map](https://github.com/Guaranteed-Rate/lazy-map):
 
 * More robust handling of laziness: all possible operations on maps
   are supported correctly (e.g. `seq` and `reduce-kv`)
-* Pretty string representation and support for pretty-printing
+* Pretty string representations that preserve laziness
+
+
+Features unique to [malabarba/lazy-map](https://github.com/Malabarba/lazy-map-clojure):
+
+* ClojureScript support
+* Transform Java classes into lazy maps (methods become keys)

--- a/src/lazy_map/core.clj
+++ b/src/lazy_map/core.clj
@@ -385,7 +385,7 @@
 (defn lazy-map
   "Constructs a lazy map from a map that may contain delays for values."
   ([] (->LazyMap {}))
-  ([m] (if (lazy-map? m) m (->LazyMap m))))
+  ([m] (if (lazy-map? m) m (->LazyMap (or m {})))))
 
 
 (defmacro literal->lazy-map

--- a/test/lazy_map/core_test.clj
+++ b/test/lazy_map/core_test.clj
@@ -2,7 +2,6 @@
   (:require [lazy-map.core :refer :all]
             [clojure.test :refer :all]
             [clojure.pprint :as pp])
-  (:import [lazy_map.core LazyMap])
   (:refer-clojure :exclude (merge)))
 
 (defmacro error
@@ -19,7 +18,7 @@
 
 (defn make-lazy-map
   [& [constructor]]
-  ((or constructor ->LazyMap)
+  ((or constructor lazy-map)
    {:a (delay (error "value :a should not be realized"))
     :b 50
     :c (delay (error "value :c should not be realized"))}))
@@ -29,13 +28,13 @@
     (is (= (:b (make-lazy-map))
            50))
     (is (= (with-out-str
-             (:c (->LazyMap
+             (:c (lazy-map
                    {:a (delay (error "value :a should not be realized"))
                     :b 50
                     :c (delay (print "value :c was realized"))})))
            "value :c was realized")))
   (testing "lazy maps can be called as fns"
-    (is (= (let [m (->LazyMap
+    (is (= (let [m (lazy-map
                      {:a 1
                       :b 2})]
              (m :b))
@@ -44,7 +43,7 @@
     (is (= (set
              (keys (make-lazy-map)))
            #{:a :b :c}))
-    (is (= (->> (->LazyMap
+    (is (= (->> (lazy-map
                   {:a (delay (println "value :a was realized"))
                    :b (delay (println "value :b was realized"))
                    :c (delay (println "value :c was realized"))})
@@ -72,12 +71,12 @@
     (is (= (get (make-lazy-map) :d :default)
            :default)))
   (testing "seqs for lazy maps do not contain delays"
-    (is (= (set (->LazyMap
+    (is (= (set (lazy-map
                   {:a 1
                    :b (delay 2)}))
            #{[:a 1] [:b 2]})))
   (testing "equality for lazy maps"
-    (is (= (->LazyMap
+    (is (= (lazy-map
              {:a 1
               :b (delay 2)})
            {:a 1
@@ -86,31 +85,31 @@
     (is (= (reduce (fn [m [k v]]
                      (assoc m k v))
                    {}
-                   (->LazyMap
+                   (lazy-map
                      {:a 1
                       :b (delay 2)}))
            {:a 1 :b 2}))
     (is (= (reduce-kv (fn [m k v]
                         (assoc m k v))
                       {}
-                      (->LazyMap
+                      (lazy-map
                         {:a 1
                          :b (delay 2)}))
            {:a 1 :b 2})))
   (testing "str representation of lazy maps"
-    (is (= (str (->LazyMap {:a 1}))
+    (is (= (str (lazy-map {:a 1}))
            "{:a 1}"))
-    (is (= (str (->LazyMap {:a (delay 1)}))
+    (is (= (str (lazy-map {:a (delay 1)}))
            "{:a <unrealized>}")))
   (testing "pr-str representation of lazy maps"
-    (is (= (pr-str (->LazyMap {:a 1}))
+    (is (= (pr-str (lazy-map {:a 1}))
            "{:a 1}"))
-    (is (= (pr-str (->LazyMap {:a (delay 1)}))
+    (is (= (pr-str (lazy-map {:a (delay 1)}))
            "{:a <unrealized>}")))
   (testing "pprint representation of lazy maps"
-    (is (= (with-out-str (pp/pprint (->LazyMap {:a 1})))
+    (is (= (with-out-str (pp/pprint (lazy-map {:a 1})))
            (format "{:a 1}%n")))
-    (is (= (with-out-str (pp/pprint (->LazyMap {:a (delay 1)})))
+    (is (= (with-out-str (pp/pprint (lazy-map {:a (delay 1)})))
            (format "{:a <unrealized>}%n"))))
   (testing "str representation of lazy map entries"
     (is (= (str (lazy-map-entry :a 1))
@@ -127,15 +126,9 @@
            (format "[:a 1]%n")))
     (is (= (with-out-str (pp/pprint (lazy-map-entry :a (delay 1))))
            (format "[:a <unrealized>]%n"))))
-  (testing "->?LazyMap function"
-    (is (= (:b (make-lazy-map ->?LazyMap))
-           50))
-    (is (not (instance? LazyMap
-                        (.contents ^LazyMap
-                                   (->?LazyMap (make-lazy-map)))))))
   (testing "lazy-map macro"
     (is (= (with-out-str
-             (let [m (lazy-map
+             (let [m (literal->lazy-map
                        {:a (println "value :a was realized")
                         :b (println "value :b was realized")
                         :c (println "value :c was realized")})]
@@ -143,7 +136,7 @@
                  (k m))))
            (format "value :b was realized%nvalue :c was realized%n"))))
   (testing "forcing a lazy map"
-    (is (= (->> (lazy-map
+    (is (= (->> (literal->lazy-map
                   {:a (println "value :a was realized")
                    :b (println "value :b was realized")})
                 (force-map)
@@ -163,17 +156,24 @@
         :b 50
         :c "c"}))
   (testing "keyIterator and valIterator"
-    (is (= false (.hasNext (.keyIterator (lazy-map {})))))
-    (is (= true (.hasNext (.keyIterator (lazy-map {:a 1})))))
-    (is (= :a (.next (.keyIterator (lazy-map {:a 1})))))
-    (is (= :a (.next (.keyIterator (lazy-map {:a 1})))))
-    (is (= false (.hasNext (.valIterator (lazy-map {})))))
-    (is (= true (.hasNext (.valIterator (lazy-map {:a 1})))))
-    (is (= 1 (.next (.valIterator (lazy-map {:a 1}))))))
+    (is (= false (.hasNext (.keyIterator (literal->lazy-map {})))))
+    (is (= true (.hasNext (.keyIterator (literal->lazy-map {:a 1})))))
+    (is (= :a (.next (.keyIterator (literal->lazy-map {:a 1})))))
+    (is (= :a (.next (.keyIterator (literal->lazy-map {:a 1})))))
+    (is (= false (.hasNext (.valIterator (literal->lazy-map {})))))
+    (is (= true (.hasNext (.valIterator (literal->lazy-map {:a 1})))))
+    (is (= 1 (.next (.valIterator (literal->lazy-map {:a 1}))))))
   (testing "empty maps"
-    (is (empty? (keys (lazy-map {}))))
-    (is (empty? (vals (lazy-map {}))))
-    (is (= (count (lazy-map {})) 0))))
+    (is (empty? (keys (literal->lazy-map {}))))
+    (is (empty? (vals (literal->lazy-map {}))))
+    (is (= (count (literal->lazy-map {})) 0))
+    (is (lazy-map? (empty (literal->lazy-map {})))))
+
+  (testing "literals are not wrapped in delays."
+    (let [m (literal->lazy-map {:a :b})]
+      (is (realized-at? m :a)))
+    (let [m (literal->lazy-map {:a (+ 1 2 3)})]
+      (is (not (realized-at? m :a))))))
 
 
 (deftest laziness-of-nested-maps
@@ -181,7 +181,7 @@
         !       (fn [x] (swap! effects conj x) x)
         reset!! (fn [] (reset! effects []))]
     (testing "nested maps as map values"
-      (let [m (lazy-map {:a {:b (! :c)}})]
+      (let [m (literal->lazy-map {:a {:b (! :c)}})]
         (is (empty? @effects))
         (get m :a)
         (is (empty? @effects))
@@ -190,7 +190,7 @@
       (reset!!))
 
     (testing "nested maps within vectors"
-      (let [m (lazy-map {:a [{:b (! :c)}]})]
+      (let [m (literal->lazy-map {:a [{:b (! :c)}]})]
         (is (empty? @effects))
         (get m :a)
         (is (empty? @effects))
@@ -201,7 +201,7 @@
       (reset!!))
 
     (testing "nested maps within sets"
-      (let [m (lazy-map {:a #{{:b (! :c)}}})]
+      (let [m (literal->lazy-map {:a #{{:b (! :c)}}})]
         (is (empty? @effects))
         (-> m :a)
         (is (empty? @effects))
@@ -212,7 +212,7 @@
       (reset!!))
 
     (testing "nested maps within function calls"
-      (let [m (lazy-map {:a (do {:b (! :c)})})]
+      (let [m (literal->lazy-map {:a (do {:b (! :c)})})]
         (is (empty? @effects))
         (-> m :a)
         (is (empty? @effects))
@@ -221,25 +221,42 @@
       (reset!!))))
 
 (deftest merge-test
-  (let [effects (atom [])
-        !       (fn [x] (swap! effects conj x) x)
-        m1      (lazy-map {:a (! :a1) :b (! :b1)})
-        m2      (lazy-map {:a (! :a2) :c (! :c2)})
-        merged  (merge m1 m2)]
-    (is (empty? @effects))
-    (is (= :a2 (get merged :a)))
-    (is (= [:a2] @effects))
-    (is (= :b1 (get merged :b)))
-    (is (= [:a2 :b1] @effects))
-    (is (= :c2 (get merged :c)))
-    (is (= [:a2 :b1 :c2] @effects))))
+  (testing "simple merge"
+    (let [effects (atom [])
+          !       (fn [x] (swap! effects conj x) x)
+          m1      (literal->lazy-map {:a (! :a1) :b (! :b1)})
+          m2      (literal->lazy-map {:a (! :a2) :c (! :c2)})
+          merged  (merge m1 m2)]
+      (is (empty? @effects))
+      (is (= :a2 (get merged :a)))
+      (is (= [:a2] @effects))
+      (is (= :b1 (get merged :b)))
+      (is (= [:a2 :b1] @effects))
+      (is (= :c2 (get merged :c)))
+      (is (= [:a2 :b1 :c2] @effects))))
+
+  (testing "preservation of already realized values"
+    (let [effects (atom [])
+          !       (fn [x] (swap! effects conj x) x)
+          a       (literal->lazy-map {:a :a1 :b (! :b1)})
+          b       (literal->lazy-map {:b :b2})
+          merged  (merge a b)]
+      (is (empty? @effects))
+      (is (not (realized-at? a :b)))
+      (is (realized-at? b :b))
+      (is (realized-at? merged :a))
+      (is (= :a1 (get merged :a)))
+      (is (empty? @effects))
+      (is (realized-at? merged :b))
+      (is (= :b2 (get merged :b)))
+      (is (empty? @effects)))))
 
 (deftest deep-merge-test
   (testing "simple deep merge"
     (let [effects (atom [])
           !       (fn [x] (swap! effects conj x) x)
-          m1      (lazy-map {:a (! :a1) :b (! :b1)})
-          m2      (lazy-map {:a (! :a2) :c (! :c2)})
+          m1      (literal->lazy-map {:a (! :a1) :b (! :b1)})
+          m2      (literal->lazy-map {:a (! :a2) :c (! :c2)})
           merged  (deep-merge m1 m2)]
       (is (empty? @effects))
       (is (= :a2 (get merged :a)))
@@ -252,8 +269,8 @@
   (testing "nested deep merge"
     (let [effects (atom [])
           !       (fn [x] (swap! effects conj x) x)
-          m1      (lazy-map {:a (! :a1) :b {:c (! :c1) :d (! :d1)}})
-          m2      (lazy-map {:a (! :a2) :b {:c (! :c2) :e (! :e2)}})
+          m1      (literal->lazy-map {:a (! :a1) :b {:c (! :c1) :d (! :d1)}})
+          m2      (literal->lazy-map {:a (! :a2) :b {:c (! :c2) :e (! :e2)}})
           merged  (deep-merge m1 m2)]
       (is (empty? @effects))
       (is (= :a2 (get merged :a)))
@@ -261,4 +278,20 @@
       (is (= :c2 (get-in merged [:b :c])))
       (is (= [:a2 :c2] @effects))
       (is (= :d1 (get-in merged [:b :d])))
-      (is (= [:a2 :c2 :d1] @effects)))))
+      (is (= [:a2 :c2 :d1] @effects))))
+
+  (testing "preservation of already realized values"
+    (let [effects (atom [])
+          !       (fn [x] (swap! effects conj x) x)
+          a       (literal->lazy-map {:a :a1 :b (! :b1)})
+          b       (literal->lazy-map {:b :b2})
+          merged  (deep-merge a b)]
+      (is (empty? @effects))
+      (is (not (realized-at? a :b)))
+      (is (realized-at? b :b))
+      (is (realized-at? merged :a))
+      (is (= :a1 (get merged :a)))
+      (is (empty? @effects))
+      (is (realized-at? merged :b))
+      (is (= :b2 (get merged :b)))
+      (is (empty? @effects)))))


### PR DESCRIPTION
- variable arity merge / deep-merge
- rename public api functions for clarity
- `(empty m)` should return an empty lazy map instance
- add `lazy-map?` predicate
- `force-map` should only copy lazy-maps not all maps
- default to no-op behavior in `lazy-map` constructor if handed a lazy-map
- simplify readme
- improve perf ~5-10x by removing reflection
- `merge` and `deep-merge` shouldn't wrap already realized values in delays again
- `literal->lazy-map` shouldn't wrap values in delays that are already definitively realized